### PR TITLE
Reworking Rails scopes

### DIFF
--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -17,8 +17,8 @@ class City < ActiveRecord::Base
   default_scope { order :name }
   attr_accessible :name, :name_variants, :notes
 
-  scope :ordered, -> { where(:order => ['name ASC']) }
-  scope :attributes_for_select_list, -> { where(:select =>[ '`name`, `id`']) }
+  scope :ordered, -> { order 'name ASC' }
+  scope :attributes_for_select_list, -> { select(:name, :id) }
   scope :with_name_like, lambda { |*name|
     where("#{quoted_table_name}.`name` LIKE ?", "%#{name.flatten.first}%") unless name.flatten.first.blank?
   }

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -12,10 +12,10 @@
 class Location < ActiveRecord::Base
   has_many :microfilms
 
-  default_scope {order :name}
+  default_scope { order :name }
 
-  scope :ordered, -> { where(:order => 'name ASC') }
-  scope :attributes_for_select_list, -> { where(:select => ['`name`, `id`']) }
+  scope :ordered, -> { order('name ASC') }
+  scope :attributes_for_select_list, -> { select(:name, :id) }
 
   attr_accessible :name, :notes
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,11 +16,8 @@ class User < ActiveRecord::Base
 
   default_scope { order([:last_name, :first_name]) }
   scope :ordered, lambda { |*order|
-    { :order => order.flatten.first || [:last_name, :first_name] }
+    order( order.flatten.first || [:last_name, :first_name] )
   }
-
-  scope :non_privileged, -> { where(:conditions => ["#{quoted_table_name}.`administrator` = ?", false]) }
-  scope :administrators, -> { where(:conditions => ["#{quoted_table_name}.`administrator` = ?", true]) }
 
   def self.create_user_with_username(username)
     new_user = User.new(:username => username)


### PR DESCRIPTION
In the process of upgrading, the format for Rails ActiveRecord scopes
changed. This commit reflects that.

In addition, I removed 2 scopes on User (`User.administrators` and
`User.non_privileged`) as they were no longer used.