### PR TITLE
Working on rails admin for mm

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,10 +30,10 @@ module ApplicationHelper
   end
 
   def edit_record_link
-    model_name, id = params[:id].split('-')
+    model_class_name, id = params[:id].split('-')
 
-    if can? :edit, model_name.camelize.constantize
-      link_to 'Edit this Record', url_for(:controller => "admin/#{model_name.pluralize}", :action => 'edit', :id => id), :class => 'edit-record'
+    if can? :edit, model_class_name.camelize.constantize
+      link_to 'Edit this Record', url_for(:controller => "admin/#{model_class_name.pluralize}", :action => 'edit', :id => id), :class => 'edit-record'
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,21 @@ module ApplicationHelper
   end
 
   def icon_destroy_admin_link(model, message)
-    link_to image_tag('icons/bin_closed.png', :alt => 'Destroy', :title => 'Destroy'), { :controller => "admin/#{model.class.to_s.tableize}", :action => 'destroy', :id => model}, :confirm => message, :method => :delete, :class => 'icon-link'
+    link_to(
+      image_tag(
+        'icons/bin_closed.png',
+        :alt => 'Destroy',
+        :title => 'Destroy'
+      ), {
+        :controller => "admin/#{model.class.to_s.tableize}",
+        :action => 'destroy',
+        :id => model
+      }, {
+        :data => { :confirm => message },
+        :method => :delete,
+        :class => 'icon-link'
+      }
+    )
   end
 
   def edit_record_link

--- a/app/models/default_attribute_type.rb
+++ b/app/models/default_attribute_type.rb
@@ -3,7 +3,7 @@
 # Table name: default_attribute_types
 #
 #  id             :integer          not null, primary key
-#  model_name     :string(255)
+#  model_class_name     :string(255)
 #  attribute_name :string(255)
 #  is_model_id    :boolean
 #  created_at     :datetime

--- a/app/views/admin/users/_default_attribute.html.erb
+++ b/app/views/admin/users/_default_attribute.html.erb
@@ -3,7 +3,7 @@
   <%= form.label :default_attribute_type_value, form.object.default_attribute_type.attribute_name.titleize %>
   <% if form.object.default_attribute_type.is_model_id? %>
     <%= form.collection_select :value,
-                               form.object.default_attribute_type.model_name.camelize.constantize.ordered.all,
+                               form.object.default_attribute_type.model_class_name.camelize.constantize.ordered.all,
                                :id,
                                :collection_name,
                                :prompt => 'Please make a selection',

--- a/db/migrate/20200319125528_rename_model_name_to_model_class_name.rb
+++ b/db/migrate/20200319125528_rename_model_name_to_model_class_name.rb
@@ -1,0 +1,5 @@
+class RenameModelNameToModelClassName < ActiveRecord::Migration
+  def change
+    rename_column :default_attribute_types, :model_name, :model_class_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,87 +11,87 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130402161936) do
+ActiveRecord::Schema.define(version: 20200319125528) do
 
-  create_table "bookmarks", force: true do |t|
-    t.integer  "user_id",     null: false
-    t.string   "document_id"
-    t.string   "title"
+  create_table "bookmarks", force: :cascade do |t|
+    t.integer  "user_id",     limit: 4,   null: false
+    t.string   "document_id", limit: 255
+    t.string   "title",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "user_type"
+    t.string   "user_type",   limit: 255
   end
 
-  create_table "cities", force: true do |t|
-    t.string   "name"
-    t.string   "name_variants"
-    t.string   "notes"
+  create_table "cities", force: :cascade do |t|
+    t.string   "name",          limit: 255
+    t.string   "name_variants", limit: 255
+    t.string   "notes",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "classifications", force: true do |t|
-    t.string   "name"
+  create_table "classifications", force: :cascade do |t|
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "classifications", ["name"], name: "index_classifications_on_name", using: :btree
 
-  create_table "classifications_facsimiles", id: false, force: true do |t|
-    t.integer "facsimile_id",      null: false
-    t.integer "classification_id", null: false
+  create_table "classifications_facsimiles", id: false, force: :cascade do |t|
+    t.integer "facsimile_id",      limit: 4, null: false
+    t.integer "classification_id", limit: 4, null: false
   end
 
   add_index "classifications_facsimiles", ["classification_id"], name: "index_classifications_facsimiles_on_classification_id", using: :btree
   add_index "classifications_facsimiles", ["facsimile_id", "classification_id"], name: "index_classifications_facsimiles_on_both_ids", using: :btree
   add_index "classifications_facsimiles", ["facsimile_id"], name: "index_classifications_facsimiles_on_facsimile_id", using: :btree
 
-  create_table "collections", force: true do |t|
-    t.string   "name"
-    t.string   "notes"
+  create_table "collections", force: :cascade do |t|
+    t.string   "name",       limit: 255
+    t.string   "notes",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "countries", force: true do |t|
-    t.string   "name"
+  create_table "countries", force: :cascade do |t|
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "countries", ["name"], name: "index_countries_on_name", using: :btree
 
-  create_table "date_ranges", force: true do |t|
-    t.string   "name"
-    t.string   "code"
+  create_table "date_ranges", force: :cascade do |t|
+    t.string   "name",       limit: 255
+    t.string   "code",       limit: 255
     t.date     "start_date"
     t.date     "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "date_ranges_facsimiles", id: false, force: true do |t|
-    t.integer "facsimile_id",  null: false
-    t.integer "date_range_id", null: false
+  create_table "date_ranges_facsimiles", id: false, force: :cascade do |t|
+    t.integer "facsimile_id",  limit: 4, null: false
+    t.integer "date_range_id", limit: 4, null: false
   end
 
   add_index "date_ranges_facsimiles", ["date_range_id"], name: "index_date_ranges_facsimiles_on_date_range_id", using: :btree
   add_index "date_ranges_facsimiles", ["facsimile_id", "date_range_id"], name: "index_date_ranges_facsimiles_on_facsimile_id_and_date_range_id", using: :btree
   add_index "date_ranges_facsimiles", ["facsimile_id"], name: "index_date_ranges_facsimiles_on_facsimile_id", using: :btree
 
-  create_table "default_attribute_types", force: true do |t|
-    t.string   "model_name"
-    t.string   "attribute_name"
+  create_table "default_attribute_types", force: :cascade do |t|
+    t.string   "model_class_name", limit: 255
+    t.string   "attribute_name",   limit: 255
     t.boolean  "is_model_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "default_attribute_values", force: true do |t|
-    t.integer  "user_id"
-    t.integer  "default_attribute_type_id"
-    t.string   "value"
+  create_table "default_attribute_values", force: :cascade do |t|
+    t.integer  "user_id",                   limit: 4
+    t.integer  "default_attribute_type_id", limit: 4
+    t.string   "value",                     limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -99,127 +99,127 @@ ActiveRecord::Schema.define(version: 20130402161936) do
   add_index "default_attribute_values", ["default_attribute_type_id"], name: "index_default_attribute_values_on_default_attribute_type_id", using: :btree
   add_index "default_attribute_values", ["user_id"], name: "index_default_attribute_values_on_user_id", using: :btree
 
-  create_table "facsimiles", force: true do |t|
-    t.string   "title"
-    t.string   "alternate_names"
-    t.string   "shelf_mark"
-    t.string   "origin"
-    t.string   "dimensions"
-    t.string   "century_keywords"
-    t.string   "date_description"
-    t.string   "author"
-    t.text     "content"
-    t.text     "hand"
+  create_table "facsimiles", force: :cascade do |t|
+    t.string   "title",                    limit: 255
+    t.string   "alternate_names",          limit: 255
+    t.string   "shelf_mark",               limit: 255
+    t.string   "origin",                   limit: 255
+    t.string   "dimensions",               limit: 255
+    t.string   "century_keywords",         limit: 255
+    t.string   "date_description",         limit: 255
+    t.string   "author",                   limit: 255
+    t.text     "content",                  limit: 65535
+    t.text     "hand",                     limit: 65535
     t.boolean  "illuminations"
-    t.text     "type_of_decoration"
+    t.text     "type_of_decoration",       limit: 65535
     t.boolean  "musical_notation"
-    t.text     "type_of_musical_notation"
-    t.string   "call_number"
+    t.text     "type_of_musical_notation", limit: 65535
+    t.string   "call_number",              limit: 255
     t.boolean  "commentary_volume"
-    t.text     "nature_of_facsimile"
-    t.string   "series"
-    t.string   "publication_date"
-    t.string   "place_of_publication"
-    t.string   "publisher"
-    t.string   "printer"
-    t.text     "notes"
-    t.text     "bibliography"
+    t.text     "nature_of_facsimile",      limit: 65535
+    t.string   "series",                   limit: 255
+    t.string   "publication_date",         limit: 255
+    t.string   "place_of_publication",     limit: 255
+    t.string   "publisher",                limit: 255
+    t.string   "printer",                  limit: 255
+    t.text     "notes",                    limit: 65535
+    t.text     "bibliography",             limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "country_id"
+    t.integer  "country_id",               limit: 4
   end
 
   add_index "facsimiles", ["country_id"], name: "index_facsimiles_on_country_id", using: :btree
 
-  create_table "facsimiles_languages", id: false, force: true do |t|
-    t.integer "facsimile_id", null: false
-    t.integer "language_id",  null: false
+  create_table "facsimiles_languages", id: false, force: :cascade do |t|
+    t.integer "facsimile_id", limit: 4, null: false
+    t.integer "language_id",  limit: 4, null: false
   end
 
   add_index "facsimiles_languages", ["facsimile_id", "language_id"], name: "index_facsimiles_languages_on_facsimile_id_and_language_id", using: :btree
   add_index "facsimiles_languages", ["facsimile_id"], name: "index_facsimiles_languages_on_facsimile_id", using: :btree
   add_index "facsimiles_languages", ["language_id"], name: "index_facsimiles_languages_on_language_id", using: :btree
 
-  create_table "facsimiles_libraries", id: false, force: true do |t|
-    t.integer "facsimile_id", null: false
-    t.integer "library_id",   null: false
+  create_table "facsimiles_libraries", id: false, force: :cascade do |t|
+    t.integer "facsimile_id", limit: 4, null: false
+    t.integer "library_id",   limit: 4, null: false
   end
 
   add_index "facsimiles_libraries", ["facsimile_id", "library_id"], name: "index_facsimiles_libraries_on_facsimile_id_and_library_id", using: :btree
   add_index "facsimiles_libraries", ["facsimile_id"], name: "index_facsimiles_libraries_on_facsimile_id", using: :btree
   add_index "facsimiles_libraries", ["library_id"], name: "index_facsimiles_libraries_on_library_id", using: :btree
 
-  create_table "languages", force: true do |t|
-    t.string   "name"
+  create_table "languages", force: :cascade do |t|
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "libraries", force: true do |t|
-    t.string   "name"
-    t.string   "name_variants"
-    t.integer  "city_id"
+  create_table "libraries", force: :cascade do |t|
+    t.string   "name",          limit: 255
+    t.string   "name_variants", limit: 255
+    t.integer  "city_id",       limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "locations", force: true do |t|
-    t.string   "name"
-    t.string   "notes"
+  create_table "locations", force: :cascade do |t|
+    t.string   "name",       limit: 255
+    t.string   "notes",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "microfilms", force: true do |t|
-    t.string   "shelf_mark"
-    t.string   "mss_name"
-    t.text     "mss_note"
+  create_table "microfilms", force: :cascade do |t|
+    t.string   "shelf_mark",    limit: 255
+    t.string   "mss_name",      limit: 255
+    t.text     "mss_note",      limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "library_id"
-    t.integer  "location_id"
-    t.integer  "collection_id"
-    t.string   "reel"
+    t.integer  "library_id",    limit: 4
+    t.integer  "location_id",   limit: 4
+    t.integer  "collection_id", limit: 4
+    t.string   "reel",          limit: 255
   end
 
-  create_table "roles", force: true do |t|
-    t.string   "name"
+  create_table "roles", force: :cascade do |t|
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "roles_users", id: false, force: true do |t|
-    t.integer "role_id", null: false
-    t.integer "user_id", null: false
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id", limit: 4, null: false
+    t.integer "user_id", limit: 4, null: false
   end
 
   add_index "roles_users", ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id", using: :btree
   add_index "roles_users", ["role_id"], name: "index_roles_users_on_role_id", using: :btree
   add_index "roles_users", ["user_id"], name: "index_roles_users_on_user_id", using: :btree
 
-  create_table "searches", force: true do |t|
-    t.text     "query_params"
-    t.integer  "user_id"
+  create_table "searches", force: :cascade do |t|
+    t.text     "query_params", limit: 65535
+    t.integer  "user_id",      limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "user_type"
+    t.string   "user_type",    limit: 255
   end
 
   add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
 
-  create_table "users", force: true do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "username"
+  create_table "users", force: :cascade do |t|
+    t.string   "first_name",          limit: 255
+    t.string   "last_name",           limit: 255
+    t.string   "username",            limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "remember_token"
+    t.string   "remember_token",      limit: 255
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",       default: 0
+    t.integer  "sign_in_count",       limit: 4,   default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string   "current_sign_in_ip",  limit: 255
+    t.string   "last_sign_in_ip",     limit: 255
   end
 
   add_index "users", ["username"], name: "index_users_on_username", using: :btree


### PR DESCRIPTION
## Updating column name from reserved word

1da41fdfff4ddc2acf22bef7b991ce72341bacc6

Prior to this commit, `model_name` was a reserved word in Rails 4.2.x
land. This was not an issue in the earlier versions of Medieval
Microfilm, as we were on a prior Rails version.

To apply the changes, you will need to run:

```console
$ cd <RAILS_ROOT>
$ bundle exec rake db:migrate
```

## Restoring confirm to `#icon_destroy_admin_link`

fab8c15cd378e006013391181981f2d5eafcd1c9

Prior to this commit, the `:confirm => message` was ignored. The
upgrade to Rails 4.2.x is the likely culprit.

The [documentation for 4.2.11.1][1] (which this commit is working
against), moves the `:confirm => message` key/value pair as a value
of the `data` key.

[1]:https://github.com/rails/rails/blob/v4.2.11.1/actionview/lib/action_view/helpers/url_helper.rb#L173
