### PR TITLE
Ensuring the "Delete and Replace" feature works

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -41,7 +41,12 @@ class Classification < ActiveRecord::Base
   private
 
   def update_related_models
-    facsimiles.collect{|facsimile| facsimile.to_solr}
+    # Because of the below #replace_with_another_classification_if_provided, Rails
+    # cached the facsimilies, and was reindexing them as per their cached
+    # value. This resulted in no effective change. By adding a reload
+    # imperative, the facsimiles are updated to belong to another
+    # country.
+    facsimiles.reload.collect{|facsimile| facsimile.to_solr}
     Blacklight.solr.commit
   end
 

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -44,7 +44,7 @@ class Country < ActiveRecord::Base
       replacement_country = Country.find(replacement_country_id.to_i)
       if replacement_country
         self.facsimiles.each do |facsimile|
-          facsimile.country_id = replacement_country.id
+          facsimile.country = replacement_country
           facsimile.save
         end
 
@@ -54,7 +54,12 @@ class Country < ActiveRecord::Base
   end
 
   def update_related_models
-    facsimiles.collect{|facsimile| facsimile.to_solr}
+    # Because of the above #replace_with_another_country_if_provided, Rails
+    # cached the facsimilies, and was reindexing them as per their cached
+    # value. This resulted in no effective change. By adding a reload
+    # imperative, the facsimiles are updated to belong to another
+    # country.
+    facsimiles.reload.collect{|facsimile| facsimile.to_solr}
     Blacklight.solr.commit
   end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -55,7 +55,12 @@ class Language < ActiveRecord::Base
   end
 
   def update_related_models
-    facsimiles.collect{|facsimile| facsimile.to_solr}
+    # Because of the above #replace_with_another_language_if_provided, Rails
+    # cached the facsimilies, and was reindexing them as per their cached
+    # value. This resulted in no effective change. By adding a reload
+    # imperative, the facsimiles are updated to belong to another
+    # country.
+    facsimiles.reload.collect{|facsimile| facsimile.to_solr}
     Blacklight.solr.commit
   end
 end


### PR DESCRIPTION
Prior to this commit, the Country, Language, and Classification models
exposed a "Delete and Replace" feature. In Rails 4.2 (and perhaps
before work on Okta-fication began) these behaviors did not work.

The Country, Language, or Classification would be deleted. However,
due to caching of the relationships, the database records would have
the correct "Replaced" entry (except for Country, more on that later).
However, the SOLR document would have the "Deleted" entry. This is
based on timing (First we update the related facsimile, which would
run a SOLR commit, then we run the after delete cleanup method, which
would use the cached relationship to run solr updates).

This change ensures that we void the cache before we attempt to run
the update.

And why was Country / Facsimile a different case? In using
`#country_id` instead of `#country`, Rails updated the ID but not the
`#country` object of the Facsimile. When save was run on the
Facsimile, Rails favored the `#country` value instead of the
`#country_id`.

In other words, setting `Facsimile#country_id` does not update
`Facsimile#country`, but setting `Facsimile.country` does update
`Facsimile#country_id`.